### PR TITLE
Database Export and Import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ node_modules
 .DS_Store
 \.vscode/
 db/db.config
+
+# Exclude files in the directory, but keep the directory.
+db/prod/*
+!db/prod/.gitkeep

--- a/cwd/handler.js
+++ b/cwd/handler.js
@@ -2,7 +2,7 @@
 var MongoClient = require('mongodb').MongoClient;
 
 // Constants
-const dburl = 'mongodb://clevelandCwdEditor:password123@159.89.232.129:52000/cleveland-cwd';
+const dburl = 'mongodb://cwd-mongo:27017/cleveland-cwd';
 
 function getTheBird() {
   return new Promise((resolve, reject) => {

--- a/cwd/run.sh
+++ b/cwd/run.sh
@@ -2,4 +2,4 @@
 
 # add this as an option to switch to using a different path
 # -e "PATH_PREFIX=citywide-dashboard"
-docker run -dit -p 42000:80 -v $(pwd):/usr/src/app --restart always --name cwd citywide-dashboard
+docker run -dit -p 42000:80 -v $(pwd):/usr/src/app --restart always --link cwd-mongo:mongo --name cwd citywide-dashboard

--- a/db/download-prod.sh
+++ b/db/download-prod.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+mongodump --uri="mongodb://clevelandCwdEditor:password123@159.89.232.129:52000/cleveland-cwd" -o prod/

--- a/db/download-prod.sh
+++ b/db/download-prod.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mongodump --uri="mongodb://clevelandCwdEditor:password123@159.89.232.129:52000/cleveland-cwd" -o prod/
+mongodump --uri="mongodb://clevelandCwdEditor:password123@159.89.232.129:52000/cleveland-cwd" --gzip --archive > prod/dump.gz

--- a/db/upload-prod.sh
+++ b/db/upload-prod.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# Note: this script assumes that you have already downloaded the production database.
+# If you have not, please run `./download-prod.sh` first.
+
+docker exec -i cwd-mongo sh -c 'mongorestore --archive --gzip' < ./prod/dump.gz


### PR DESCRIPTION
Trello: https://trello.com/c/hyElrFEI/65-create-script-for-citywide-dashboard-database-backup

This pull request creates a new flow for handling the database.  First, the live database on some IP somewhere will not be used by us.  We will, instead, for development, download it with `./download-prod.sh` in the `db` folder.  This will download a dump file that effectively functions as a backup.  We will then use the `./upload-prod.sh` script to upload it into our local Mongo container.  This gives us a local copy to work with in development (this can be extended to having a local copy in every production, etc.).

So, to adapt your current system to using this system, need to do the following:
1. Stop your cwd container.
1. Run `./download-prod.sh` in the `db` folder
1. Run `./upload-prod.sh` in the `db` folder.
1. Rebuild and restart your cwd container.

I believe that is all, but let me know if you run into any issues.

I need to practice bass really badly, so I did this as quickly as possible to simply get it working.  There are various aspects to the flow that I would really prefer to make better in the future, but I think this is good enough to allow development for now.

Not looking to merge this until everyone has seen / approved of it, since it contains breaking changes if local set-ups are not migrated properly.