### PR TITLE
Use Docker to run mongoexport so that MongoDB versions line up

### DIFF
--- a/db/download-prod.sh
+++ b/db/download-prod.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mongodump --uri="mongodb://clevelandCwdEditor:password123@159.89.232.129:52000/cleveland-cwd" --gzip --archive > prod/dump.gz
+docker exec cwd-mongo sh -c 'mongodump --uri="mongodb://clevelandCwdEditor:password123@159.89.232.129:52000/cleveland-cwd" --gzip --archive' > prod/dump.gz


### PR DESCRIPTION
Trello: https://trello.com/c/ocQh5uQ6/67-use-docker-in-database-export-script-to-ensure-equal-mongo-versions

I will not merge this until @acrap5 tests out the process as mentioned in #4 on this branch and it actually works.  It is nice if others test it too, but I don't see it as quite as crucial.