### PR TITLE
Thickened the glow that highlights buttons

### DIFF
--- a/cwd/views/index.pug
+++ b/cwd/views/index.pug
@@ -13,7 +13,7 @@ html
               filter(id="blur" x="0" y="0")
                 feGaussianBlur(in="SourceGraphic" stdDeviation="15")
               filter(id="whiteGlow" x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" overflow="auto")
-                feMorphology(operator="dilate" radius="25" in="SourceAlpha" result="thicken")
+                feMorphology(operator="dilate" radius="50" in="SourceAlpha" result="thicken")
                 feGaussianBlur(in="thicken" stdDeviation="40" result="blurred")
                 feFlood(flood-color="rgb(235,235,235)" result="glowColor")
                 feComposite(in="glowColor" in2="blurred" operator="in" result="softGlow_colored")


### PR DESCRIPTION
Made a simple change that will increase the glow around buttons when a certain view is selected. In my opinion, this still doesn't look fantastic, since the glow is pure white against a light blue background. I think something like a soft yellow might work better so there's more contrast and it's easier to see that the buttons are highlighted, but I'll leave that decision up to the design people, as it'd be a quick fix to make.

It should also probably be noted that this glow effect is used not only for the buttons, but also as the highlight for the buildings in CWD. Is this okay, or do we want to separate the two so that the highlight/glow is only increased for the buttons?