### PR TITLE
Support further character message customization

### DIFF
--- a/cwd/app.js
+++ b/cwd/app.js
@@ -138,7 +138,22 @@
       let probMessages = messages.map(m => {
         let messagesArray = [];
 
-        for (let i = 0; i < m.probability; i++) {
+        // If probability is an array, the array corresponds with bin #s.
+        // When we do not have support for this, we will fall back to the
+        // first value of the array.
+        let addCount = 0;
+
+        if (Array.isArray(m.probability)) {
+          // Query API, then put the appropriate value here.
+          const binNum = 0;
+
+          // addCount becomes the average of the array.
+          addCount = m.probability[binNum];
+        } else {
+          addCount = m.probability;
+        }
+
+        for (let i = 0; i < addCount; i++) {
           messagesArray.push(m.text);
         }
 

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -122,6 +122,37 @@
   };
 
   /**
+   * Takes a messageable, i.e. some object that could have a `messages`
+   * attribute that corresponds to a messages array, and
+   * assigns a relevant message to the character message box.
+   */
+  const updateCharacterText = messageable => {
+    let characterText = document.getElementById('characterTextP');
+
+    if (messageable.messages) {
+      let messages = messageable.messages;
+
+      // Maps each message into an array containing it probability times,
+      // then selects a random message from this list.
+      // Note that this does not account for probability being an array.
+      let probMessages = messages.map(m => {
+        let messagesArray = [];
+
+        for (let i = 0; i < m.probability; i++) {
+          messagesArray.push(m.text);
+        }
+
+        return messagesArray;
+      }).flat();
+
+      // Gets a random message from the list of messages.
+      let message = probMessages[Math.floor(Math.random() * probMessages.length)];
+
+      characterText.textContent = message;
+    }
+  };
+
+  /**
    * Update the gauges on the DOM with the links contained in `view.gauges`.
    * @param {JSON} view The view object within a viewController object.
    */
@@ -264,13 +295,7 @@
     newView.classList.add('currentView');
     newView.style.display = "block";
 
-    // Update character text.
-    let characterText = document.getElementById('characterTextP');
-
-    if (view.message) {
-      characterText.textContent = view.message;
-    }
-
+    updateCharacterText(view);
     updateGauges(view);
     updateAnimations(view);
   };

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -173,10 +173,16 @@
    */
   const updateGauges = view => {
     if (!view.gauges) return;
+
     const gauges = view.gauges;
+
     for (let i = 0; i < gauges.length; i++) {
-      let $gauge = document.getElementById(`gauge-${i + 1}`);
-      $gauge.setAttribute('href', gauges[i]);
+      // gauges[i] is the view gauges object,
+      // gauge becomes the DOM element
+      let gauge = document.getElementById(`gauge-${i + 1}`);
+      gauge.setAttribute('href', gauges[i].url);
+
+      updateCharacterText(gauges[i]);
     }
     return;
   }


### PR DESCRIPTION
Trello: https://trello.com/c/NNFDsMBv/16-cwd-investigate-future-character-message-support-and-how-to-incorporate-it

This pull requests adds an App function, `updateCharacterText`, which takes any object that may have a `messages` attribute.  This attribute is used to set the character text, corresponding to some rules about messages arrays.  The rules are outlined in the Trello card linked.

Currently, this function will be run when gauges are updated and when the section is changed.  The change from highlighting sections to highlighting gauges will then make this run on sections, but also on each gauge shift.