### PR TITLE
Create a pipeline for external data to be retrieved and used

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,18 @@ with this project that you may have.
 Then, in the `db` directory, run `./run.sh`, then `./download-prod.sh`,
 then `./upload-prod.sh`.
 Open an issue for any further issues that develop within this process.
+
+Editing the `src/` Folder
+-------------------------
+
+Since the `app.js` file is handled directly by the web browser, it can be
+developed simply by saving the file and reloading the webpage.
+However, the `src/` folder is built into a bundle by Webpack, so it needs
+to get recompiled after being saved in order for the changes to be noticed.
+To do this, make sure you have Webpack installed (`npm install -g webpack-cli`)
+and run `webpack` in the `cwd/` folder each time you make a change inside of the
+`src/` folder.
+
+Future ease of development would call for a listener to be attached to the `src/`
+folder that will result in `webpack` automatically getting run each time that
+a file is modified.

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -36,6 +36,13 @@
   /** The amount of time in seconds between views in kiosk mode. */
   const VIEW_DURATION = 10;
 
+  /**
+   * Example of accessing API:
+   * fetch(`http://${API_URL}/glyphs`)
+   * .then(response => response.json())
+   * .then(j => console.log(j));
+   */
+
   let eventsDict = {
     viewSwitcher: function(glyph) {
       let listener = function() {

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -369,4 +369,4 @@
   } else {
     console.error('Please enable Kiosk mode.');
   }
-})(window.cwd, activeGlyphs);
+})(window.cwd, activeGlyphs, API_URL);

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -174,6 +174,16 @@
 
     glyphs.forEach(obj => {
       // if (glyphObj.name === 'bird' || glyphObj.name === 'cloud' || glyphObj.name === 'powerline') return;
+
+      // The data will arrive after the object has already been fully added to the
+      // render engine.  It is worth considering if this is okay or if
+      // the object should only arrive when its corresponding data has arrived.
+      if (obj.data_url) {
+        fetch(obj.data_url)
+        .then(r => r.json())
+        .then(j => obj.data = j);
+      }
+
       const glyph = cwd.factory(obj, eventsDict)();
       dash.addGlyph(glyph);
 

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -176,19 +176,6 @@
       // if (glyphObj.name === 'bird' || glyphObj.name === 'cloud' || glyphObj.name === 'powerline') return;
 
       const glyph = cwd.factory(obj, eventsDict)();
-
-      // Remember to store the data into the database as well.
-      if (obj.data_url) {
-        fetch(obj.data_url)
-        .then(r => r.json())
-        .then(j => {
-          obj.data = j;
-          //glyph.data = j;
-        });
-
-        console.log(glyph);
-      }
-
       dash.addGlyph(glyph);
 
       /**

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -179,6 +179,26 @@
       dash.addGlyph(glyph);
 
       /**
+       * Unfortunately, gauges are not their own glyphs.
+       * This makes it so that the factory cannot work to add data to gauges.
+       * Instead, we need to add the data while handling the view object.
+       */
+      if (obj.view && obj.view.gauges) {
+        obj.view.gauges.forEach(g => {
+          if (g.data_url) {
+            fetch(g.data_url)
+            .then(r => r.json())
+            .then(j => {
+              g.data = j;
+
+              // Then make call to store the new data into the database.
+              // This could become hard due to the nesting of gauges.
+            });
+          }
+        });
+      }
+
+      /**
        * In order for our characterText to be like other elements on the page
        * and not move when the page is resized, we need to calculate
        * the necessary offsets on page load and store them.

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -175,16 +175,20 @@
     glyphs.forEach(obj => {
       // if (glyphObj.name === 'bird' || glyphObj.name === 'cloud' || glyphObj.name === 'powerline') return;
 
-      // The data will arrive after the object has already been fully added to the
-      // render engine.  It is worth considering if this is okay or if
-      // the object should only arrive when its corresponding data has arrived.
+      const glyph = cwd.factory(obj, eventsDict)();
+
+      // Remember to store the data into the database as well.
       if (obj.data_url) {
         fetch(obj.data_url)
         .then(r => r.json())
-        .then(j => obj.data = j);
+        .then(j => {
+          obj.data = j;
+          //glyph.data = j;
+        });
+
+        console.log(glyph);
       }
 
-      const glyph = cwd.factory(obj, eventsDict)();
       dash.addGlyph(glyph);
 
       /**

--- a/cwd/package-lock.json
+++ b/cwd/package-lock.json
@@ -4726,9 +4726,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.6.tgz",
-      "integrity": "sha512-0vEa83M7kJtxK/jUhlpZ27WHIOndz5mghWL2O53kiDoA9DIxSKnfqB92LoqEn77cT4f3H2cZm1BMEat/6AZz3A==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.10.tgz",
+      "integrity": "sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==",
       "dev": true,
       "requires": {
         "chalk": "2.4.2",

--- a/cwd/package.json
+++ b/cwd/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/EnvironmentalDashboard/citywide-dashboard.alpha#readme",
   "devDependencies": {
     "webpack": "^4.39.1",
-    "webpack-cli": "^3.3.6"
+    "webpack-cli": "^3.3.10"
   },
   "dependencies": {
     "express": "^4.17.1",

--- a/cwd/run.sh
+++ b/cwd/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# API_URL needs to be set to the relevant / correct thing
+
 # add this as an option to switch to using a different path
 # -e "PATH_PREFIX=citywide-dashboard"
-docker run -dit -p 42000:80 -v $(pwd):/usr/src/app --restart always --link cwd-mongo:mongo --link cwd-be:backend --name cwd citywide-dashboard
+docker run -dit -p 42000:80 -v $(pwd):/usr/src/app --restart always -e "API_URL=localhost:3006" --link cwd-mongo:mongo --link cwd-be:backend --name cwd citywide-dashboard

--- a/cwd/run.sh
+++ b/cwd/run.sh
@@ -2,4 +2,4 @@
 
 # add this as an option to switch to using a different path
 # -e "PATH_PREFIX=citywide-dashboard"
-docker run -dit -p 42000:80 -v $(pwd):/usr/src/app --restart always --link cwd-mongo:mongo --name cwd citywide-dashboard
+docker run -dit -p 42000:80 -v $(pwd):/usr/src/app --restart always --link cwd-mongo:mongo --link cwd-be:backend --name cwd citywide-dashboard

--- a/cwd/server.js
+++ b/cwd/server.js
@@ -27,7 +27,7 @@ router.get('/', (req, res) => {
 router.get('/index', (req, res) => {
   handler.getTheBird().then(arr => {
     const activeGlyphsStr = JSON.stringify({ arr });
-    res.render('index', { activeGlyphsStr });
+    res.render('index', { activeGlyphsStr, api_url: process.env.API_URL });
   });
 });
 

--- a/cwd/src/factory.js
+++ b/cwd/src/factory.js
@@ -25,6 +25,9 @@
       // Set up variables
       let state = glyph.state;
       state._id = glyph._id;
+
+      if (glyph.data) state.data = glyph.data;
+
       let product = state;
 
       // Glyph first

--- a/cwd/src/factory.js
+++ b/cwd/src/factory.js
@@ -26,7 +26,15 @@
       let state = glyph.state;
       state._id = glyph._id;
 
-      if (glyph.data) state.data = glyph.data;
+      if (glyph.data_url) {
+        fetch(glyph.data_url)
+        .then(r => r.json())
+        .then(j => {
+          state.data = j;
+
+          // Then make call to store the new data into the database.
+        });
+      }
 
       let product = state;
 

--- a/cwd/src/factory.js
+++ b/cwd/src/factory.js
@@ -42,6 +42,10 @@
         .then(j => {
           state.data = j;
 
+          // Update the glyph's data itself.
+          // Consideration: maybe the factory shouldn't modify the provided glyph?
+          glyph.data = j;
+
           // Then make call to store the new data into the database.
         });
       }

--- a/cwd/src/factory.js
+++ b/cwd/src/factory.js
@@ -26,6 +26,16 @@
       let state = glyph.state;
       state._id = glyph._id;
 
+      /**
+       * If our glyph includes cached data, we will load this data into the object.
+       * Then, we will possibly query the provided data url and override this cached
+       * data.
+       * This allows us to have the cached data in case anything goes wrong in the query.
+       */
+      if (glyph.data) {
+        state.data = glyph.data;
+      }
+
       if (glyph.data_url) {
         fetch(glyph.data_url)
         .then(r => r.json())

--- a/cwd/views/index.pug
+++ b/cwd/views/index.pug
@@ -27,5 +27,6 @@ html
               p(id="characterTextP") Good day and welcome to Citywide Dashboard!
 
     script const activeGlyphs = !{activeGlyphsStr};
+    script const API_URL = "!{api_url}";
     script(src="./dist/cwd-bundle.js")
     script(src="./app.js")


### PR DESCRIPTION
This pull request adds the following pipeline:

Whenever a glyph is loaded from the database, first it will be loaded with cached data (called `data` - should this be renamed `cached_data`?).  Then, if it has a data URL (called `data_url`), that URL's data will be fetched and then attached to the glyph.  Now, the application can utilize the data in either engine actions or glyph actions.  I wish I knew when engine attributes are incorporated better for if it is worthwhile for the engine to have data available or not.  This is possibly a lack of internal knowledge on my part.  But either way, that is the summary of the pipeline of handling both cached and live data.

A separate change will handle updating the cache, but the database needs a backup first.

The code here is easy - the real code review is thinking about the design and if it fairly makes sense.  Comments in the code mention some of the design issues I was considering.

My ideal testing and proof-of-concept requires https://github.com/EnvironmentalDashboard/citywide-dashboard.alpha/pull/19 to be merged, and it is still struggling to get past code review, so I guess for now we need to test this in more abstract terms.