### PR TITLE
Modify upload-prod.sh to destroy current database and overwrite

### DIFF
--- a/db/upload-prod.sh
+++ b/db/upload-prod.sh
@@ -3,4 +3,5 @@
 # Note: this script assumes that you have already downloaded the production database.
 # If you have not, please run `./download-prod.sh` first.
 
+docker exec -i cwd-mongo sh -c 'mongo --quiet --eval "db.getMongo().getDBNames().forEach(function(i){db.getSiblingDB(i).dropDatabase()})"'
 docker exec -i cwd-mongo sh -c 'mongorestore --archive --gzip' < ./prod/dump.gz


### PR DESCRIPTION
Trello: https://trello.com/c/9den1WXG/125-cwd-make-uploading-production-database-locally-more-easy

This is simply a quality-of-life pull request.  No need to obliterate the `cwd-mongo` container any more - now when you upload the script will do it for you.