### PR TITLE
Character messages fix

### DIFF
--- a/cwd/app.js
+++ b/cwd/app.js
@@ -138,7 +138,7 @@
    * attribute that corresponds to a messages array, and
    * assigns a relevant message to the character message box.
    */
-  const updateCharacterText = messageable => {
+  const updateCharacterText = (messageable, view) => {
     let characterText = document.getElementById('characterTextP');
 
     const messageLength = characterText.innerText.trim().length;
@@ -190,6 +190,13 @@
 
       // Gets a random message from the list of messages.
       let message = probMessages[Math.floor(Math.random() * probMessages.length)];
+
+      if (!message && view) {
+        updateCharacterText(view);
+        return;
+      } else if (!message && !view) {
+        message = "Welcome to Citywide Dashboard!"
+      }
 
       characterText.textContent = message;
       characterText.fontSize = messageSize = 'px';
@@ -371,7 +378,7 @@
       } else {
         const gauge = document.getElementById(`gauge-${gaugeIndex + 1}`);
         gauge.classList.add('currentGauge');
-        updateCharacterText(currentView.gauges[gaugeIndex]);
+        updateCharacterText(currentView.gauges[gaugeIndex], currentView);
 
         // Prevent us from running the bottom code of the function
         // that switches to the next view.
@@ -409,7 +416,7 @@
     const current = document.getElementById(`gauge-${gaugeIndex + 1}`);
     setTimeout(function() {
       current.classList.add('currentGauge');
-      updateCharacterText(view.gauges[gaugeIndex]);
+      updateCharacterText(view.gauges[gaugeIndex], view);
       displayRotator = setInterval(() => rotateDisplay(views.map(v => v.view)), duration);
     }, duration);
 

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -195,8 +195,7 @@
       let message = probMessages[Math.floor(Math.random() * probMessages.length)];
 
       if (!message && view) {
-        updateCharacterText(view);
-        return;
+        return updateCharacterText(view);
       } else if (!message && !view) {
         message = DEFAULT_MESSAGE;
       }

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -354,7 +354,7 @@
 
   };
 
-  const rotateDisplay = (views, rotator) => {
+  const rotateDisplay = views => {
     const currentView = views[index];
     if (Array.isArray(currentView.gauges)) {
       // Remove highlight from current gauge.
@@ -384,7 +384,7 @@
     if (!window.location.hash) {
       index++;
       if (index === views.length) index = 0;
-      clearInterval(rotator);
+      clearInterval(displayRotator);
       renderView(views[index]);
     } else {
       gaugeIndex = 0;
@@ -409,7 +409,7 @@
     setTimeout(function() {
       current.classList.add('currentGauge');
       updateCharacterText(view.gauges[gaugeIndex]);
-      displayRotator = setInterval(() => rotateDisplay(views.map(v => v.view), displayRotator), VIEW_DURATION * 1000);
+      displayRotator = setInterval(() => rotateDisplay(views.map(v => v.view)), VIEW_DURATION * 1000);
     }, VIEW_DURATION * 1000);
 
     // Remove highlight from previous view and highlight current one

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -57,24 +57,21 @@
 
         if(SHOW_ONE_TITLE) {
           const buttons = Array.prototype.slice.call(document.getElementsByClassName("glow-on-hover")).filter(obj => obj.id.includes("Button"));
-          const index = buttons.indexOf(document.getElementById(this.id));
+          index = buttons.indexOf(document.getElementById(this.id));
           buttons[index].style.display = "none";
 
           if (displayRotator) clearInterval(displayRotator);
 
           if (index != buttons.length - 1) {
-            buttons[index+1].style.display = "block";
-            renderView(views[index+1].view);
-            if(window.location.hash)
-              window.location.hash = views[index+1].hash;
-
+            index++;
           } else if (buttons.length > 0) {
-            buttons[0].style.display = "block";
-            renderView(views[0].view);
-            if(window.location.hash)
-              window.location.hash = views[0].hash;
-
+            index = 0;
           }
+
+          buttons[index].style.display = "block";
+          renderView(views[index].view);
+          if(window.location.hash) window.location.hash = views[index].hash;
+
         } else {
           renderView(glyph.view);
         }

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -210,8 +210,6 @@
       // gauge becomes the DOM element
       let gauge = document.getElementById(`gauge-${i + 1}`);
       gauge.setAttribute('href', gauges[i].url);
-
-      updateCharacterText(gauges[i]);
     }
     return;
   }
@@ -356,9 +354,8 @@
 
   };
 
-  const rotateDisplay = views => {
+  const rotateDisplay = (views, rotator) => {
     const currentView = views[index];
-
     if (Array.isArray(currentView.gauges)) {
       // Remove highlight from current gauge.
       const gauge = document.getElementById(`gauge-${gaugeIndex + 1}`);
@@ -374,6 +371,7 @@
       } else {
         const gauge = document.getElementById(`gauge-${gaugeIndex + 1}`);
         gauge.classList.add('currentGauge');
+        updateCharacterText(currentView.gauges[gaugeIndex]);
 
         // Prevent us from running the bottom code of the function
         // that switches to the next view.
@@ -386,6 +384,7 @@
     if (!window.location.hash) {
       index++;
       if (index === views.length) index = 0;
+      clearInterval(rotator);
       renderView(views[index]);
     } else {
       gaugeIndex = 0;
@@ -407,7 +406,11 @@
     // The first gauge of the current view gets highlighted
     gaugeIndex = 0;
     const current = document.getElementById(`gauge-${gaugeIndex + 1}`);
-    current.classList.add('currentGauge');
+    setTimeout(function() {
+      current.classList.add('currentGauge');
+      updateCharacterText(view.gauges[gaugeIndex]);
+      const displayRotator = setInterval(() => rotateDisplay(views.map(v => v.view), displayRotator), VIEW_DURATION * 1000);
+    }, VIEW_DURATION * 1000);
 
     // Remove highlight from previous view and highlight current one
     Array.from(document.getElementsByClassName('currentView'))
@@ -483,9 +486,6 @@
       startEngine(allGlyphs);
       renderView(views[index].view);
     });
-
-    setInterval(() => rotateDisplay(views.map(v => v.view)), duration * 1000);
-
   }
 
   if (KIOSK_MODE) {

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -6,6 +6,7 @@
 
   gaugeIndex = 0;
   index = 0;
+  displayRotator = null;
 
   // This makes sure width isn't too big for the screen, and switches to calculate based off of full width
   var height =
@@ -58,6 +59,8 @@
           const buttons = Array.prototype.slice.call(document.getElementsByClassName("glow-on-hover")).filter(obj => obj.id.includes("Button"));
           const index = buttons.indexOf(document.getElementById(this.id));
           buttons[index].style.display = "none";
+
+          if (displayRotator) clearInterval(displayRotator);
 
           if (index != buttons.length - 1) {
             buttons[index+1].style.display = "block";
@@ -409,7 +412,7 @@
     setTimeout(function() {
       current.classList.add('currentGauge');
       updateCharacterText(view.gauges[gaugeIndex]);
-      const displayRotator = setInterval(() => rotateDisplay(views.map(v => v.view), displayRotator), VIEW_DURATION * 1000);
+      displayRotator = setInterval(() => rotateDisplay(views.map(v => v.view), displayRotator), VIEW_DURATION * 1000);
     }, VIEW_DURATION * 1000);
 
     // Remove highlight from previous view and highlight current one

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -398,6 +398,7 @@
    */
   const renderView = view => {
     console.log(`Rendering view: ${view.name}`);
+    const duration = VIEW_DURATION * 1000;
 
     // Removes highlight from previous gauge if any
     const previous = document.getElementById(`gauge-${gaugeIndex + 1}`);
@@ -409,8 +410,8 @@
     setTimeout(function() {
       current.classList.add('currentGauge');
       updateCharacterText(view.gauges[gaugeIndex]);
-      displayRotator = setInterval(() => rotateDisplay(views.map(v => v.view)), VIEW_DURATION * 1000);
-    }, VIEW_DURATION * 1000);
+      displayRotator = setInterval(() => rotateDisplay(views.map(v => v.view)), duration);
+    }, duration);
 
     // Remove highlight from previous view and highlight current one
     Array.from(document.getElementsByClassName('currentView'))

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -40,6 +40,9 @@
   /** The amount of time in seconds between views in kiosk mode. */
   const VIEW_DURATION = 2;
 
+  /** Default message to be shown only if the DB has no messages. */
+  const DEFAULT_MESSAGE = "Welcome to Citywide Dashboard!";
+
   /**
    * Example of accessing API:
    * fetch(`http://${API_URL}/glyphs`)
@@ -195,7 +198,7 @@
         updateCharacterText(view);
         return;
       } else if (!message && !view) {
-        message = "Welcome to Citywide Dashboard!"
+        message = DEFAULT_MESSAGE;
       }
 
       characterText.textContent = message;


### PR DESCRIPTION
This pull request tackles two issues in one. Firstly, we wanted Citywide Dashboard to "hold" on each view and display a "welcome message" relating to the view before rotating through each of its gauges. This adds that functionality. Secondly, there was a bug where all gauge message calculations were performed when the page was first loaded instead of each time the gauge changes. This bug is corrected in this pull request as well.

https://trello.com/c/lER2B2hs/37-cwd-gauge-rotation-holds-at-only-the-view-at-first
https://trello.com/c/0AOAG3Bl/38-cwd-fix-bug-of-firing-all-gauge-message-calculations-at-the-same-time