### PR TITLE
change to one water droplet in the pipes

### DIFF
--- a/cwd/app.js
+++ b/cwd/app.js
@@ -409,8 +409,8 @@
     console.log(`Rendering view: ${view.name}`);
     const duration = VIEW_DURATION * 1000;
 
-    // Set our CSS on the pipes to be 3 dots.
-    $('.flowable path:last-of-type, .flowable line:last-of-type').css('stroke-dasharray', '0 15 0 15 0 120');
+    // Set our CSS on the pipes from num_droplets in database. If num_droplets doesn't exist the default will be 1 droplet.
+    $('.flowable path:last-of-type, .flowable line:last-of-type').css('stroke-dasharray', `${'0 15 '.repeat(view.num_droplets-1)}0 120`);
 
     // Removes highlight from previous gauge if any
     const previous = document.getElementById(`gauge-${gaugeIndex + 1}`);

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -410,7 +410,8 @@
     const duration = VIEW_DURATION * 1000;
 
     // Set our CSS on the pipes from num_droplets in database. If num_droplets doesn't exist the default will be 1 droplet.
-    $('.flowable path:last-of-type, .flowable line:last-of-type').css('stroke-dasharray', `${'0 15 '.repeat(view.num_droplets-1)}0 120`);
+    if (view.num_droplets)
+      $('.flowable path:last-of-type, .flowable line:last-of-type').css('stroke-dasharray', `${'0 15 '.repeat(view.num_droplets-1)}0 120`);
 
     // Removes highlight from previous gauge if any
     const previous = document.getElementById(`gauge-${gaugeIndex + 1}`);

--- a/cwd/app.js
+++ b/cwd/app.js
@@ -409,6 +409,9 @@
     console.log(`Rendering view: ${view.name}`);
     const duration = VIEW_DURATION * 1000;
 
+    // Set our CSS on the pipes to be 3 dots.
+    $('.flowable path:last-of-type, .flowable line:last-of-type').css('stroke-dasharray', '0 15 0 15 0 120');
+
     // Removes highlight from previous gauge if any
     const previous = document.getElementById(`gauge-${gaugeIndex + 1}`);
     if (previous) previous.classList.remove('currentGauge');

--- a/cwd/public/styleSheet.css
+++ b/cwd/public/styleSheet.css
@@ -89,7 +89,7 @@ body,
   animation-iteration-count: infinite;
   animation-direction: reverse;
 
-  stroke-dasharray: 0 15 0 15 0 120;
+  stroke-dasharray: 0 120;
   stroke-linecap: round;
 
   display: none;

--- a/cwd/public/styleSheet.css
+++ b/cwd/public/styleSheet.css
@@ -100,7 +100,7 @@ body,
 }
 
 @keyframes water {
-  to { stroke-dashoffset: 150 }
+  to { stroke-dashoffset: 240 }
 }
 
 .electron {

--- a/cwd/views/index.pug
+++ b/cwd/views/index.pug
@@ -38,3 +38,4 @@ html
     script const API_URL = "!{api_url}";
     script(src="./dist/cwd-bundle.js")
     script(src="./app.js")
+    script(src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous")


### PR DESCRIPTION
This PR modifies water-droplet animation so that only one water droplet appears in the pipes during the lake view. This animation occurs in the `styleSheet.css` file, and @Sammidysam realized we would want there to be an entry in the database corresponding to the number of water droplets, providing scalability, but I can't think of an immediate solution to that. Thoughts? 